### PR TITLE
fix: read version from package.json at runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import axios from 'axios';
+import { createRequire } from 'module';
+
+// Read version from package.json so it stays in sync automatically
+const require = createRequire(import.meta.url);
+const { version: PACKAGE_VERSION } = require('../package.json');
 
 // Environment variable configuration
 const MOODLE_API_URL = process.env.MOODLE_API_URL;
@@ -101,7 +106,7 @@ class MoodleMcpServer {
     this.server = new Server(
       {
         name: 'moodle-mcp-server',
-        version: '0.2.0', // Updated version for multi-course support
+        version: PACKAGE_VERSION,
       },
       {
         capabilities: {


### PR DESCRIPTION
## Summary
- Replace hardcoded version string `'0.2.0'` in `src/index.ts` with a dynamic read from `package.json` using `createRequire`
- `package.json` is now the single source of truth for the version — the MCP server protocol response and logs will always match the published package version
- Prevents version mismatches between npm tags and what the server reports

## What changed
```typescript
// Before
version: '0.2.0', // Updated version for multi-course support

// After
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
const { version: PACKAGE_VERSION } = require('../package.json');
// ...
version: PACKAGE_VERSION,
```

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — all 20 tests pass
- [ ] After merging: bump version, publish, restart Claude Desktop, verify version in logs matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)